### PR TITLE
Allow setting due date without time

### DIFF
--- a/src/app/helpers.py
+++ b/src/app/helpers.py
@@ -51,20 +51,28 @@ class DateTimeHelper:
 
     @staticmethod
     def convert_to_iso8601_jst(date_str: str) -> str:
-        try:
-            dt = datetime.strptime(date_str, "%Y-%m-%d-%H:%M")
-            dt_with_tz = dt.replace(second=0, microsecond=0, tzinfo=DateTimeHelper.JST_TZ)
-            return dt_with_tz.isoformat()
-        except Exception:
-            raise ValueError("Invalid date format. Use YYYY-MM-DD-HH:MM")
+        formats = ["%Y-%m-%d-%H:%M", "%Y-%m-%d"]
+        for fmt in formats:
+            try:
+                dt = datetime.strptime(date_str, fmt)
+                if fmt == "%Y-%m-%d":
+                    dt = dt.replace(hour=0, minute=0)
+                dt_with_tz = dt.replace(second=0, microsecond=0, tzinfo=DateTimeHelper.JST_TZ)
+                return dt_with_tz.isoformat()
+            except Exception:
+                continue
+        return "Invalid date format"
 
     @staticmethod
     def validate_date_format(date_str: str) -> bool:
-        try:
-            datetime.strptime(date_str, "%Y-%m-%d-%H:%M")
-            return True
-        except ValueError:
-            return False
+        formats = ["%Y-%m-%d-%H:%M", "%Y-%m-%d"]
+        for fmt in formats:
+            try:
+                datetime.strptime(date_str, fmt)
+                return True
+            except ValueError:
+                continue
+        return False
 
 
 class TaskDisplayHelper:

--- a/src/main.py
+++ b/src/main.py
@@ -280,8 +280,8 @@ class TodoApp(App):
                     Label("Task Name (required):", classes="label"),
                     CustomInput(placeholder="Enter task name...", id="task-name"),
 
-                    Label("Deadline (YYYY-MM-DD-HH:MM, optional):", classes="label"),
-                    CustomInput(placeholder="e.g., 2024-12-31-23:59", id="due-date"),
+                    Label("Deadline (YYYY-MM-DD or YYYY-MM-DD-HH:MM, optional):", classes="label"),
+                    CustomInput(placeholder="e.g., 2024-12-31 or 2024-12-31-23:59", id="due-date"),
 
                     Label("Description:", classes="label"),
                     CustomTextArea(placeholder="Enter task description...", id="description"),


### PR DESCRIPTION
タスクの新規作成・編集について，due_date を YYYY-MM-DD-HH:MM 形式に加えて 時間を含まない YYYY-MM-DD 形式にも対応させました．