### PR TITLE
Fix search mode

### DIFF
--- a/src/handlers/handlers.py
+++ b/src/handlers/handlers.py
@@ -380,6 +380,11 @@ class ActionHandler:
             updated_task = self.app.controller.toggle_task_completion(selected_task.id)
             if updated_task:
                 self.app.load_tasks()
+                if self.app.app_mode == "search_results":
+                    search_term = self.app.previous_search_term
+                    self.app.ui_manager.show_search_results(search_term)
+                elif self.app.app_mode == "list":
+                    return
 
     def handle_delete_mode(self):
         if self.app.app_mode not in ["list", "search_results"]:


### PR DESCRIPTION
検索モードで完了未完了をトグルしたときに発生する以下のバグを修正した．
・完了未完了が最初に一度しかトグルされない
・タスクを削除するとタスク一覧に戻ってしまう
・完了未完了をトグルすると左右の参照しているタスクの同期が取れていない